### PR TITLE
Add `status` column - tickets/INSTRM-2669

### DIFF
--- a/python/actorkeys/ag.py
+++ b/python/actorkeys/ag.py
@@ -1,6 +1,6 @@
 KeysDictionary(
     'ag',
-    (1, 11),
+    (1, 12),
     Key('text', String(), help='Human oriented message string',),
     Key('version', String(), help='Actor version string',),
     Key('guideReady', Bool('0', '1'), help='Ready to guide',),
@@ -23,6 +23,7 @@ KeysDictionary(
         Float(name='dAlt', units='arcsec', help='Altitude error'),
         Float(name='dZ', units='mm', help='Focus error'),
         Float(name='dScale', help='Scale error'),
+        String(name='status', help='Status information about the errors'),
     ),
     Key('focusErrors',
         Int(name='exposureId', help='Exposure identifier'),


### PR DESCRIPTION
* Adds a `status` string column to `guideErrors` key to provide textual information about the calculated errors, e.g. were they invalid or not.